### PR TITLE
Get count for particular state, and subscribe to daily updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .vscode
 *.log
 *.json
+*.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__
 .vscode
 *.log
 *.json
-*.env
+.env

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Cases identified in a particular state.
 
 /subscribe
 Get daily updates at 09:00 pm IST.
+
+/unsubscribe
+Unsubscribe from daily updates.
 ```
 
 ## Sources:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ List of statewise cases in India.
 
 /about
 Info about the bot and the source.
+
+/state
+Cases identified in a particular state.
 ```
 
 ## Sources:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Info about the bot and the source.
 
 /state
 Cases identified in a particular state.
+
+/subscribe
+Get daily updates at 09:00 pm IST.
 ```
 
 ## Sources:

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackContext
 import telegram
 import requests
 import logging
@@ -6,38 +6,39 @@ import messages
 from env import getenv
 
 
-def start(bot, update):
+def start(update: telegram.Update, context: CallbackContext):
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=messages.msg_start, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=messages.msg_start, parse_mode=telegram.ParseMode.HTML)
 
-def about(bot, update):
+def about(update: telegram.Update, context: CallbackContext):
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=messages.msg_about, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=messages.msg_about, parse_mode=telegram.ParseMode.HTML)
 
-def count(bot, update):
+def count(update: telegram.Update, context: CallbackContext):
     message = messages.get_count_msg()
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
-def today(bot, update):
+def today(update: telegram.Update, context: CallbackContext):
     message = messages.get_today_msg()
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
-def lastupdated(bot, update):
+def lastupdated(update: telegram.Update, context: CallbackContext):
     message = messages.get_lastupdated_msg()
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
-def statewise(bot, update):
+def statewise(update: telegram.Update, context: CallbackContext):
     message = messages.get_statewise_msg()
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
-def handle_message(bot, update):
+def handle_message(update: telegram.Update, context: CallbackContext):
+    print(update.message)
     message = 'Hi'
     chat_id = update.message.chat_id
-    bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
 def main():
     updater = Updater(getenv('API_KEY'), use_context=True)

--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@ import telegram
 import requests
 import logging
 import messages
+import re
 from env import getenv
 
 
@@ -34,9 +35,23 @@ def statewise(update: telegram.Update, context: CallbackContext):
     chat_id = update.message.chat_id
     context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
+def state(update: telegram.Update, context: CallbackContext):
+    message = messages.ask_state_msg()
+    chat_id = update.message.chat_id
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML, reply_markup=telegram.ForceReply())
+
 def handle_message(update: telegram.Update, context: CallbackContext):
-    print(update.message)
-    message = 'Hi'
+    message = messages.default_msg()
+    if update.message.reply_to_message:
+        if update.message.reply_to_message.text == messages.ask_state_msg():
+            message = messages.get_state_msg(update.message.text)
+
+    if re.match('Hi', update.message.text, re.IGNORECASE):
+        message = messages.hello_msg(update.message.chat.first_name)
+
+    elif re.match('count', update.message.text, re.IGNORECASE):
+        message = messages.get_count_msg()
+
     chat_id = update.message.chat_id
     context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
@@ -51,6 +66,7 @@ def main():
     dp.add_handler(CommandHandler('statewise',statewise))
     dp.add_handler(CommandHandler('about',about))
     dp.add_handler(CommandHandler('lastupdated',lastupdated))
+    dp.add_handler(CommandHandler('state', state))
     dp.add_handler(MessageHandler(Filters.text, handle_message))
 
     updater.start_polling()

--- a/bot.py
+++ b/bot.py
@@ -46,10 +46,10 @@ def handle_message(update: telegram.Update, context: CallbackContext):
         if update.message.reply_to_message.text == messages.ask_state_msg():
             message = messages.get_state_msg(update.message.text)
 
-    if re.match('Hi', update.message.text, re.IGNORECASE):
+    if re.match('hi|hello|hey', update.message.text, re.IGNORECASE):
         message = messages.hello_msg(update.message.chat.first_name)
 
-    elif re.match('count', update.message.text, re.IGNORECASE):
+    elif re.match('.*count.*', update.message.text, re.IGNORECASE):
         message = messages.get_count_msg()
 
     chat_id = update.message.chat_id

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-from telegram.ext import Updater, CommandHandler
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
 import telegram
 import requests
 import logging
@@ -34,9 +34,13 @@ def statewise(bot, update):
     chat_id = update.message.chat_id
     bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
+def handle_message(bot, update):
+    message = 'Hi'
+    chat_id = update.message.chat_id
+    bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 
 def main():
-    updater = Updater(getenv('API_KEY'))
+    updater = Updater(getenv('API_KEY'), use_context=True)
     dp = updater.dispatcher
     logging.basicConfig(filename='bot.log', filemode='w', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
     dp.add_handler(CommandHandler('start',start))
@@ -46,6 +50,7 @@ def main():
     dp.add_handler(CommandHandler('statewise',statewise))
     dp.add_handler(CommandHandler('about',about))
     dp.add_handler(CommandHandler('lastupdated',lastupdated))
+    dp.add_handler(MessageHandler(Filters.text, handle_message))
 
     updater.start_polling()
     updater.idle()

--- a/bot.py
+++ b/bot.py
@@ -52,6 +52,9 @@ def handle_message(update: telegram.Update, context: CallbackContext):
     elif re.match('.*count.*', update.message.text, re.IGNORECASE):
         message = messages.get_count_msg()
 
+    elif re.match('.*state.*', update.message.text, re.IGNORECASE):
+        state(update, context)
+
     chat_id = update.message.chat_id
     context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
 

--- a/bot.py
+++ b/bot.py
@@ -48,8 +48,8 @@ def get_users():
             data = json.load(f)
             return data
     except Exception as e:
-        if type(e).__name__ == 'JSONDecodeError':
-            open('users.json', 'w').write(json.dumps({}))
+        if type(e).__name__ == 'JSONDecodeError' or type(e).__name__ == 'FileNotFoundError':
+            open('users.json', 'w+').write(json.dumps({}))
             return {}
         else:
             logging.error("Exception occured", exc_info=True)
@@ -106,6 +106,12 @@ def handle_message(update: telegram.Update, context: CallbackContext):
 
     elif re.match('.*state', update.message.text, re.IGNORECASE):
         state(update, context)
+
+    elif re.match('.*unsubscribe', update.message.text, re.IGNORECASE):
+        unsubscribe(update, context)
+    
+    elif re.match('.*subscribe', update.message.text, re.IGNORECASE):
+        subscribe(update, context)
 
     chat_id = update.message.chat_id
     context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)

--- a/bot.py
+++ b/bot.py
@@ -69,6 +69,7 @@ def daily_message(context: CallbackContext):
 
 def subscribe(update: telegram.Update, context: CallbackContext):
     chat_id = update.message.chat_id
+
     users = get_users()
     user_data = {
         "username": update.message.chat.username,
@@ -79,6 +80,17 @@ def subscribe(update: telegram.Update, context: CallbackContext):
 
     message = messages.subscription_success()
     context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+
+def unsubscribe(update: telegram.Update, context: CallbackContext):
+    chat_id = update.message.chat_id
+
+    users = get_users()
+    del users[str(chat_id)]
+    save_users(users)
+
+    message = messages.unsubscription_success()
+    context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
+
 
 def handle_message(update: telegram.Update, context: CallbackContext):
     message = messages.default_msg()
@@ -111,6 +123,7 @@ def main():
     dp.add_handler(CommandHandler('lastupdated',lastupdated))
     dp.add_handler(CommandHandler('state', state))
     dp.add_handler(CommandHandler('subscribe', subscribe))
+    dp.add_handler(CommandHandler('unsubscribe', unsubscribe))
     dp.add_handler(MessageHandler(Filters.text, handle_message))
 
     updater.job_queue.run_daily(

--- a/bot.py
+++ b/bot.py
@@ -49,10 +49,10 @@ def handle_message(update: telegram.Update, context: CallbackContext):
     if re.match('hi|hello|hey', update.message.text, re.IGNORECASE):
         message = messages.hello_msg(update.message.chat.first_name)
 
-    elif re.match('.*count.*', update.message.text, re.IGNORECASE):
+    elif re.match('.*count', update.message.text, re.IGNORECASE):
         message = messages.get_count_msg()
 
-    elif re.match('.*state.*', update.message.text, re.IGNORECASE):
+    elif re.match('.*state', update.message.text, re.IGNORECASE):
         state(update, context)
 
     chat_id = update.message.chat_id

--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@ import telegram
 import requests
 import logging
 import messages
+from env import getenv
 
 
 def start(bot, update):
@@ -35,7 +36,7 @@ def statewise(bot, update):
 
 
 def main():
-    updater = Updater('API KEY')
+    updater = Updater(getenv('API_KEY'))
     dp = updater.dispatcher
     logging.basicConfig(filename='bot.log', filemode='w', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
     dp.add_handler(CommandHandler('start',start))

--- a/env.py
+++ b/env.py
@@ -1,0 +1,12 @@
+from dotenv import load_dotenv
+import os
+from pathlib import Path
+
+load_dotenv(verbose=True)
+
+env_path = Path('.') / '.env'
+
+load_dotenv(dotenv_path=env_path)
+
+def getenv(var_name):
+    return os.getenv(var_name)

--- a/messages.py
+++ b/messages.py
@@ -160,3 +160,6 @@ Updated on {updated_on}
 def subscription_success():
     return """You have successfully subscribed!
 You will receive daily updates at 9:00pm IST."""
+
+def unsubscription_success():
+    return "You have successfully unsubscribed to daily updates."

--- a/messages.py
+++ b/messages.py
@@ -125,3 +125,34 @@ def get_statewise_msg():
     statewise_msg += get_footer(data)
 
     return statewise_msg
+
+def default_msg():
+    return 'Sorry, I don\'t understand that!'
+
+def hello_msg(name):
+    return 'Hello, {name}!'.format(name=name)
+
+def ask_state_msg():
+    return 'Which state do you want the count for?'
+
+def get_state_msg(state_name):
+    data = get_data()
+    states = data['statewise']
+    details = {}
+    state_msg = 'State {state} not found!'
+    for state in states:
+        if state['state'].lower() == state_name.lower():
+            details = state
+            break
+    
+    if details != {}:
+        state_msg = """<b>Number of Covid-19 cases in {state_name}:</b>
+
+😷 Confirmed: <b>{confirmed}</b>  [+{deltaconfirmed}]
+🔴 Active: <b>{active}</b>
+💚 Recovered: <b>{recovered}</b>  [+{deltarecovered}]
+💀 Deceased: <b>{deaths}</b>  [+{deltadeaths}]
+
+Updated on {updated_on}
+    """.format(state_name=details['state'], confirmed=details["confirmed"], deltaconfirmed=details["deltaconfirmed"], active=details['active'], recovered=details['recovered'], deltarecovered=details['deltarecovered'], deaths=details['deaths'], deltadeaths=details['deltadeaths'], updated_on=pretty_date_time(details['lastupdatedtime']))
+    return state_msg

--- a/messages.py
+++ b/messages.py
@@ -156,3 +156,7 @@ def get_state_msg(state_name):
 Updated on {updated_on}
     """.format(state_name=details['state'], confirmed=details["confirmed"], deltaconfirmed=details["deltaconfirmed"], active=details['active'], recovered=details['recovered'], deltarecovered=details['deltarecovered'], deaths=details['deaths'], deltadeaths=details['deltadeaths'], updated_on=pretty_date_time(details['lastupdatedtime']))
     return state_msg
+
+def subscription_success():
+    return """You have successfully subscribed!
+You will receive daily updates at 9:00pm IST."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests==2.23.0
 six==1.14.0
 tornado==6.0.4
 urllib3==1.25.8
+python-dotenv==0.12.0

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+API_KEY=<your Telegram API KEY>


### PR DESCRIPTION
The following **features** have been included:
- Get `API KEY` from a `.env` file, handled by file `env.py`.
- Bot can now reply to text messages, used `MessageHandler` in `bot.py`.
- Deprecation warning removed, bot now uses context as recommended by latest telegram API. Checkout [Transition guide to Version 12.0](https://git.io/fxJuV) for details.
- Added another command handler called `/state`. This will ask you for a state name and find the count for the particular state. The message is written in `messages.py`.
- Default message and hello message have also been added in `messages.py`.
- `README.md` updated to include the new `/state`, `/subscribe` and '/unsubscribe' feature.
- The bot now saves subscribed users in `users.json`.
- It can send all subscribed users a message at **15:30 UTC** or **21:00 IST** about the total count for the day. The following is the code snippet that takes care of that:
```python
updater.job_queue.run_daily(   # updater refers to telegram.ext.Updater
    daily_message,
    time(hour=15, minute=30),   # time refers to datetime.time()
    name='daily_count',
    days=(0, 1, 2, 3, 4, 5, 6),
)
```
- Users can also unsubscribe to the daily updates.