### PR TITLE
fix: Unauthorized error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -152,7 +152,7 @@ def main():
 
     updater.job_queue.run_daily(
         daily_message,
-        time(hour=17, minute=22),
+        time(hour=15, minute=30),
         name='daily_count',
         days=(0, 1, 2, 3, 4, 5, 6),
     )


### PR DESCRIPTION
The following changes were made:

## Fixes:
- The bot does not crash while sending updates to subscribed user
    * The bot used to crash before since some user had blocked the bot, which returned a 403 Unauthorized error. Now that is handle in the try-except block:
```python
for chat_id in users:
    try:
        context.bot.send_message(chat_id=chat_id, text=message, parse_mode=telegram.ParseMode.HTML)
    except Exception as e:
        if type(e).__name__ == 'Unauthorized':
            print('{name} has blocked the bot.'.format(name=users[chat_id]['first_name']))
        continue
```
## Refactor:
- The code in `/subscribe` and `/start` now uses the same function `add_user`, instead of calling `get_users` and `save_users` multiple times.
```python
def add_user(chat_id, username, first_name):
    users = get_users()
    user_data = {
        "username": username,
        "first_name": first_name,
    }
    users[str(chat_id)] = user_data
    save_users(users)
```